### PR TITLE
change 0.90.8 and 4.6.0 issue #14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.6</elasticsearch.version>
-        <lucene.version>4.5.1</lucene.version>
+        <elasticsearch.version>0.90.8</elasticsearch.version>
+        <lucene.version>4.6.0</lucene.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Update to Elasticsearch 0.90.8 / Lucene 4.6.0.
Only change version number in pom.xml 
