### PR TITLE
Added plug-in test hooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,4 +278,34 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+      <profile>
+        <id>default</id>
+        <activation>
+          <activeByDefault>true</activeByDefault>
+        </activation>
+      </profile>
+
+      <profile>
+        <id>plugin-test</id>
+        <activation>
+          <property>
+            <name>tests.plugin</name>
+          </property>
+        </activation>
+
+        <properties>
+          <elasticsearch.lib>${basedir}/elasticsearch/target</elasticsearch.lib>
+        </properties>
+
+        <repositories>
+          <repository>
+            <id>ElasticsearchRepo</id>
+            <name>ElasticsearchRepo</name>
+            <url>file://${elasticsearch.lib}</url>
+          </repository>
+        </repositories>
+      </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Create Jenkins hook for plug in testing.   For testing against certain Elasticsearch branch (master for example), elasticsearch and elasticsearch-test.jar will be build from the source.
