### PR TITLE
update compatibility matrix for elasticsearch 1.4.5 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ You need to install a version matching your Elasticsearch version:
 | master        |  Build from source          | See below  |
 | es-1.x        |  Build from source          | [2.6.0-SNAPSHOT](https://github.com/elasticsearch/elasticsearch-analysis-kuromoji/tree/es-1.x/#version-260-snapshot-for-elasticsearch-1x)  |
 |    es-1.5              |     2.5.0         | [2.5.0](https://github.com/elastic/elasticsearch-analysis-kuromoji/tree/v2.5.0/#version-250-for-elasticsearch-15)                  |
-|    es-1.4              |     2.4.2         | [2.4.2](https://github.com/elasticsearch/elasticsearch-analysis-kuromoji/tree/v2.4.2/#version-242-for-elasticsearch-14)                  |
+|    es-1.4              |     2.4.3         | [2.4.3](https://github.com/t-cyrill/elasticsearch-analysis-kuromoji/blob/es-1.4/README.md#version-243-snapshot-for-elasticsearch-14)                  |
+| < 1.4.5       |     2.4.2             | [2.4.2](https://github.com/elasticsearch/elasticsearch-analysis-kuromoji/tree/v2.4.2/#version-242-for-elasticsearch-14)                  |
 | < 1.4.3       |     2.4.1             | [2.4.1](https://github.com/elasticsearch/elasticsearch-analysis-kuromoji/tree/v2.4.1/#version-241-for-elasticsearch-14)                  |
 | es-1.3        |  2.3.0                      | [2.3.0](https://github.com/elasticsearch/elasticsearch-analysis-kuromoji/tree/v2.3.0/#japanese-kuromoji-analysis-for-elasticsearch)  |
 | es-1.2        |  2.2.0                      | [2.2.0](https://github.com/elasticsearch/elasticsearch-analysis-kuromoji/tree/v2.2.0/#japanese-kuromoji-analysis-for-elasticsearch)  |


### PR DESCRIPTION
I tried to use elasticsearch-1.4.5 with elasticsearch-analysis-kuromoji-2.4.2.
When starting elasticsearch, errors occured as blew.

```
[2015-04-30 18:09:45,240][ERROR][plugins                  ] [Coldfire] cannot start plugin due to incorrect Lucene version: plugin [4.10.3], node [4.10.4].
[2015-04-30 18:09:45,241][WARN ][plugins                  ] [Coldfire] failed to load plugin from [jar:file:/usr/share/elasticsearch/plugins/analysis-kuromoji/elasticsearch-analysis-kuromoji-2.4.2.jar!/es-plugin
org.elasticsearch.ElasticsearchException: Failed to load plugin class [org.elasticsearch.plugin.analysis.kuromoji.AnalysisKuromojiPlugin]
        at org.elasticsearch.plugins.PluginsService.loadPlugin(PluginsService.java:532)
        at org.elasticsearch.plugins.PluginsService.loadPluginsFromClasspath(PluginsService.java:407)
        at org.elasticsearch.plugins.PluginsService.<init>(PluginsService.java:116)
        at org.elasticsearch.node.internal.InternalNode.<init>(InternalNode.java:151)
        at org.elasticsearch.node.NodeBuilder.build(NodeBuilder.java:159)
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:70)
        at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:207)
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:32)
Caused by: org.elasticsearch.ElasticsearchException: Plugin is incompatible with the current node
        at org.elasticsearch.plugins.PluginsService.loadPlugin(PluginsService.java:525)
        ... 7 more
```

I found issue #55, and try install 2.4.3. But failed. 2.4.3 isn't released yet.

Then I update compatibility matrix in README.
Please use the PR. Thank you.